### PR TITLE
JWT expiration offset configurable

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -2,6 +2,8 @@ server:
   address: ":8080"
 security:
   secretKey:
+  jwt:
+    expirationOffsetMins:
 mail:
   from: 
   smtp: 

--- a/internal/common/token.go
+++ b/internal/common/token.go
@@ -8,9 +8,10 @@
 package common
 
 import (
-	"github.com/golang-jwt/jwt/v5"
 	"math/rand"
 	"time"
+
+	"github.com/golang-jwt/jwt/v5"
 )
 
 func GenerateRandomString(length int) string {
@@ -29,7 +30,7 @@ func CreateToken(email string) (string, error) {
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256,
 		jwt.MapClaims{
 			"email": email,
-			"exp":   time.Now().Add(time.Hour * 24).Unix(),
+			"exp":   time.Now().Add(time.Minute * time.Duration(GetIntValue("security.jwt.expirationOffsetMins"))).Unix(),
 		})
 	tokenStr, err := token.SignedString(secretKey)
 	if err != nil {


### PR DESCRIPTION
Making the JWT expiration offset configurable in minutes. This means
that the amount of minutes configured, are added on top of the current
timestamp. The result will be the expiration date of the jwt.
