### PR TITLE
Adding Dockerfile for creating a small image via podman or docker. 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM docker.io/golang:alpine AS builder
+
+RUN apk update && \
+    apk add --no-cache gcc libc-dev
+
+WORKDIR /app
+
+COPY . .
+
+RUN CGO_ENABLED=1 go build -ldflags="-s -w -extldflags '-static'" -tags netgo -installsuffix netgo  -o goauth /app/cmd/goauth
+
+FROM scratch
+
+WORKDIR /app
+
+# This line is necessary for email notification for registering a new user
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /app/goauth .
+COPY --from=builder /app/config/ config/
+COPY --from=builder /app/templates/ templates/
+
+EXPOSE 8080
+
+CMD ["/app/goauth"]

--- a/README.md
+++ b/README.md
@@ -3,11 +3,25 @@
 Trivial implementation (for now), of the OAuth 2.0 Authorization Code Flow with PKCE
 (backend side).
 
-## Build And Run
+## Run
 
 ```bash
 go build ./cmd/goauth
 ./goauth
+```
+
+## Build
+For creating a container image the script __build-container-image.sh__ can be used. This script
+supports building the image with podman and docker. Podman is the default configuration of this
+script. For using docker the flag "D" has to be set.
+
+Build with podman:
+```bash
+./build-container-image.sh <tag-name>
+```
+Build with docker:
+```bash
+./build-container-image.sh -D <tag-name>
 ```
 
 ## Tools

--- a/build-container-image.sh
+++ b/build-container-image.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+docker_force=false
+
+function check_command() {
+  command_to_check=$1
+  if ! command -v "$command_to_check" &> /dev/null; then
+    echo "$command_to_check is not installed. Please install $command_to_check first."
+    exit 1
+  fi
+}
+
+function check_image_built() {
+  container_command=$1
+  container_name=$2
+  if "$container_command" images | grep -q "$container_name"; then
+      echo "Image $container_name successfully built"
+      else
+        echo "Image could not be created..."
+  fi
+}
+
+while getopts D opt; do
+    case $opt in
+        D) docker_force=true ;;
+        ?) echo "script usage: $(basename $0) [-D]" >&2; exit 1;;
+    esac
+done
+
+# remove the parsed options from the positional params
+shift $(( OPTIND - 1 ))
+container_tag_name=$1
+
+if $docker_force; then
+  check_command docker
+  docker build -t "$container_tag_name" .
+  check_image_built docker "$container_tag_name"
+else
+  check_command podman
+  podman build -t "$container_tag_name" .
+  check_image_built podman "$container_tag_name"
+fi


### PR DESCRIPTION
The Dockerfile contains 2 steps. The builder will build the go image. The second step takes the deployable and creates a very small image with the goauth application.

A script was created which can be called for building goauth by podman. Podman is the prefered tool to build the image. By using the force Flag -D, a docker build can be triggered.

closes #5 