### PR TITLE
Example k8s configuration

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,0 +1,14 @@
+# K8S Deployment
+
+This folder contains example k8s configuration. Ensure to read carefully
+through the configuration, and adapt it to your needs. The following
+parts are contaiend in the deployment descriptor:
+- Actual Deployment of the service
+- k8s service
+- Ingress
+- HPA
+
+To deploy the system ensure to reference the correct docker image from your registry, then:
+```bash
+kubectl apply -f deployment.yaml
+```

--- a/deployment/deployment.yaml
+++ b/deployment/deployment.yaml
@@ -1,0 +1,78 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: goauth
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: goauth
+  template:
+    metadata:
+      labels:
+        app: goauth
+    spec:
+      containers:
+      - name: goauth-container
+        image: goauth-image:latest
+        ports:
+        - containerPort: 8080
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "200Mi"
+          limits:
+            cpu: "200m"
+            memory: "400Mi"
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: goauth
+spec:
+  selector:
+    app: goauth
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8080
+  type: ClusterIP
+---
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: goauth-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: goauth
+  minReplicas: 1
+  maxReplicas: 10
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 50
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: goauth-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /goauth
+        pathType: Prefix
+        backend:
+          service:
+            name: goauth
+            port:
+              number: 80
+


### PR DESCRIPTION
Adding an example k8s configuration, that enables one to deploy goauth
in a kubernetes cluster. The configuration features the deployment,
k8s service, ingress and an hpa.

The config is setup pretty basic, and must be adjusted according to the
needs of ones use-case.
