### PR TITLE
Supporting env precedence in viper

### DIFF
--- a/internal/common/conf.go
+++ b/internal/common/conf.go
@@ -22,6 +22,7 @@ const (
 // InitializeConfiguration we initially need to tell viper how to access the configuration
 // which type the configuration is of, and where it's located.
 func InitializeConfiguration() {
+	viper.AutomaticEnv()
 	viper.SetConfigType(configType)
 	viper.AddConfigPath(primaryConfigLocation)
 	viper.AddConfigPath(secondaryConfigLocation)


### PR DESCRIPTION
Env will be a higher precedence than cnf files, and are enabled now for
easy on the go configuration.
